### PR TITLE
Tracking Constant Propagation Transform Bug

### DIFF
--- a/.github/workflows/setup-oss-cad-suite/action.yml
+++ b/.github/workflows/setup-oss-cad-suite/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install Tabby OSS Cad Suite
       shell: bash
       env:
-        VERSION: 2021-11-09
+        VERSION: 2023-05-10
       run: |
         ARTIFACT=oss-cad-suite-linux-x64-$(echo $VERSION | tr -d '-')
         wget -q -O - https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${VERSION}/${ARTIFACT}.tgz | tar -zx


### PR DESCRIPTION
Bumping yosys to a modern release reveals a bug in the constant propagation pass (see https://github.com/ucb-bar/firrtl2/pull/14#issuecomment-1541058014). Debugging will require manual testcase minimization or bisecting.