### PR TITLE
-skip-packages ... no longer works; use -skip-packages:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,8 +100,7 @@ lazy val docSettings = Seq(
   Compile / doc / scalacOptions ++= Seq(
     // ANTLR-generated classes aren't really part of public API and cause
     // errors in ScalaDoc generation
-    "-skip-packages",
-    "firrtl2.antlr",
+    "-skip-packages:firrtl2.antlr",
     "-Xfatal-warnings",
     "-feature",
     "-diagrams",


### PR DESCRIPTION
Running `sbt publishLocal` caused a build-failure on my end. This is caused by the fact that the sbt instructions used a removed syntax for scaladoc: ["-skip-packages", "..."] instead of "-skip-packages:...". See https://github.com/lampepfl/dotty/issues/14939. `-skip-packages`is deprecated, but at least works.

Now 'sbt +publishLocal' works without errors.

Without this fix, I got the following error with `sbt +publishLocal`:
[errmsg.txt](https://github.com/ucb-bar/firrtl2/files/13380335/errmsg.txt)
<details>
<summary>scaladoc failed</summary>
```shell
  [info] welcome to sbt 1.8.2 (Red Hat, Inc. Java 17.0.8)  
  [info] loading settings for project firrtl2-build from plugins.sbt ...  
  [info] loading project definition from /home/nikita/src/firrtl2/project  
  [info] loading settings for project firrtl from build.sbt ...  
  [info] set current project to firrtl2 (in build file:/home/nikita/src/firrtl2/)  
  [info] Setting Scala version to 2.13.10 on 2 projects.  
  [info] Reapplying settings...  
  [info] set current project to firrtl2 (in build file:/home/nikita/src/firrtl2/)  
  [info] Wrote /home/nikita/src/firrtl2/target/scala-2.13/firrtl2_2.13-6.0-SNAPSHOT.pom  
  [info] Main Scala API documentation to /home/nikita/src/firrtl2/target/scala-2.13/unidoc...  
  [info] Main Scala API documentation successful.  
  [info] :: delivering :: edu.berkeley.cs#firrtl2_2.13;6.0-SNAPSHOT :: 6.0-SNAPSHOT :: integration :: Thu Nov 16 14:03:07 CET 2023  
  [info]  delivering ivy file to /home/nikita/src/firrtl2/target/scala-2.13/ivy-6.0-SNAPSHOT.xml  
  [info]  published firrtl2_2.13 to /home/nikita/.ivy2/local/edu.berkeley.cs/firrtl2_2.13/6.0-SNAPSHOT/poms/firrtl2_2.13.pom  
  [info]  published firrtl2_2.13 to /home/nikita/.ivy2/local/edu.berkeley.cs/firrtl2_2.13/6.0-SNAPSHOT/jars/firrtl2_2.13.jar  
  [info]  published firrtl2_2.13 to /home/nikita/.ivy2/local/edu.berkeley.cs/firrtl2_2.13/6.0-SNAPSHOT/srcs/firrtl2_2.13-sources.jar  
  [info]  published firrtl2_2.13 to /home/nikita/.ivy2/local/edu.berkeley.cs/firrtl2_2.13/6.0-SNAPSHOT/docs/firrtl2_2.13-javadoc.jar  
  [info]  published ivy to /home/nikita/.ivy2/local/edu.berkeley.cs/firrtl2_2.13/6.0-SNAPSHOT/ivys/ivy.xml  
  [success] Total time: 44 s, completed Nov 16, 2023, 2:03:07 PM  
  [info] Setting Scala version to 3.2.2 on 2 projects.  
  [info] Reapplying settings...  
  [info] set current project to firrtl2 (in build file:/home/nikita/src/firrtl2/)  
  [info] Wrote /home/nikita/src/firrtl2/target/scala-3.2.2/firrtl2_3-6.0-SNAPSHOT.pom  
  [info] Main Scala API documentation to /home/nikita/src/firrtl2/target/scala-3.2.2/unidoc...  
  [warn] bad option '-diagrams' was ignored  
  [warn] bad option '-diagrams-max-classes' was ignored  
  [warn] Flag -project set repeatedly  
  [error] missing argument for option -skip-packages  
  [info]   scaladoc -help  gives more information  
  [info] Skipping unused scalacOptions: -Werror  
  [error] (Scalaunidoc / doc) DottyDoc Compilation Failed  
  [error] Total time: 3 s, completed Nov 16, 2023, 2:03:10 PM
 ```
</details>

I would like to use Chisel 6.0.0-M3 for [my project (very WIP)](https://github.com/nbfalcon/spark-rv/tree/main), but for that I need chiseltest-6.0.0. 6.0-SNAPSHOT, which is not released yet and is as such is not on maven, so I had to build it (and this package, since it is a dependency) from source and publish it locally. (Using Chisel 6.0.0-M3 + chiseltest 5.0.2 results in a class loading error at runtime, since some deprecated classes were removed in chisel 6.0.0).

(Only for context) Here is how I build all packages:
- [buildsetup.sh](https://github.com/nbfalcon/spark-rv/blob/6271732630d461f185541a5142dbbd2ae2e0fa76/buildsetup.sh).
- firrtl2 is built using `sbt +publishLocal` (`+` to cross-build for scala 3/2.13).
- [build.sbt](https://github.com/nbfalcon/spark-rv/blob/6271732630d461f185541a5142dbbd2ae2e0fa76/build.sbt)

### Contributor Checklist

- N/A Did you add at least one test demonstrating the PR?
- N/A Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- Fix a build failure when running `sbt publishLocal`